### PR TITLE
fix: force posix paths and use packageJsonDir option if set with gitAssets

### DIFF
--- a/packages/nx-semantic-release/src/executors/semantic-release/plugins.ts
+++ b/packages/nx-semantic-release/src/executors/semantic-release/plugins.ts
@@ -86,9 +86,15 @@ export const resolvePlugins = (
       {
         message: options.commitMessage,
         assets: [
-          // Git requires relative paths from project root
-          path.relative(context.cwd, options.changelogFile),
-          path.join(relativeProjectPath, 'package.json'),
+          // Git requires relative paths from project root in a posix format
+          path
+            .relative(context.cwd, options.changelogFile)
+            .split(path.sep)
+            .join(path.posix.sep),
+          path
+            .join(relativeProjectPath, 'package.json')
+            .split(path.sep)
+            .join(path.posix.sep),
           ...(options.gitAssets ?? []),
         ],
       },

--- a/packages/nx-semantic-release/src/executors/semantic-release/plugins.ts
+++ b/packages/nx-semantic-release/src/executors/semantic-release/plugins.ts
@@ -47,8 +47,9 @@ export const resolvePlugins = (
   options: SemanticReleaseOptions,
   context: ExecutorContext
 ) => {
-  const projectRoot = getDefaultProjectRoot(context);
-  const relativeProjectPath = path.relative(context.cwd, projectRoot);
+  const packageJsonDir =
+    options.packageJsonDir ?? getDefaultProjectRoot(context);
+  const relativeProjectPkgPath = path.relative(context.cwd, packageJsonDir);
 
   const emptyArray = [] as unknown as release.PluginSpec;
   const defaultPlugins: release.PluginSpec[] = [
@@ -92,7 +93,7 @@ export const resolvePlugins = (
             .split(path.sep)
             .join(path.posix.sep),
           path
-            .join(relativeProjectPath, 'package.json')
+            .join(relativeProjectPkgPath, 'package.json')
             .split(path.sep)
             .join(path.posix.sep),
           ...(options.gitAssets ?? []),


### PR DESCRIPTION
The packageJsonDir was not be used with gitAssets also the git plugin apparently only supports posix style paths and not win32 paths.