### PR TITLE
fix: Support nested nx repositories

### DIFF
--- a/packages/nx-semantic-release/src/common/git.ts
+++ b/packages/nx-semantic-release/src/common/git.ts
@@ -95,8 +95,7 @@ async function listAffectedFilesInCommit(
   return files
     .toString()
     .split('\n')
-    .filter(Boolean)
-    .map((line) => line.split('\t')[1])
+    .map((line) => line?.split('\t')?.[1])
     .filter(Boolean)
     .filter((filePath: string) => {
       // only include files inside the nx root

--- a/packages/nx-semantic-release/src/common/git.ts
+++ b/packages/nx-semantic-release/src/common/git.ts
@@ -1,4 +1,5 @@
 import type { Commit, Context } from 'semantic-release';
+import process from 'process';
 import { ProjectGraph } from '@nrwl/devkit';
 import { exec } from '../utils/exec';
 import { calculateFileChanges } from '@nrwl/workspace/src/core/file-utils';
@@ -82,6 +83,13 @@ export function shouldSkipCommit(
 async function listAffectedFilesInCommit(
   commit: Pick<Commit, 'commit'>
 ): Promise<string[]> {
+  // eg. /code/Repo/frontend/
+  const cwd = process.cwd() + '/';
+  // eg. /code/Repo/
+  const repositoryRoot = await exec('git rev-parse --show-toplevel') + '/';
+  // Matches the start of a path from the git root to the nx root
+  const nxPathPart = new RegExp(`^${cwd.substring(repositoryRoot.length)}`);
+
   const files = await exec(`git show --name-status ${commit.commit.short}`);
 
   return files
@@ -89,5 +97,14 @@ async function listAffectedFilesInCommit(
     .split('\n')
     .filter(Boolean)
     .map((line) => line.split('\t')[1])
-    .filter(Boolean);
+    .filter(Boolean)
+    .filter((filePath: string) => {
+      // only include files inside the nx root
+      return filePath.match(nxPathPart);
+    })
+    .map((filePath: string) => {
+        // The filepaths start from the root of the git repository, but
+        // in our case we want them to start from the nx root.
+        return filePath.replace(nxPathPart, '');
+    });
 }


### PR DESCRIPTION
This fixes #46 

We can tell if the nx monorepo is nested because there will be a difference between the git root and the nx root. So we trim all filepaths that start with that difference.

Additionally I don't include any files outside of the nx folder.

I've tested it on:
- My nested monorepo and it works
- Non-nested mono repo and it works as before