### PR TITLE
feat: allow skipping/including commits impacting multiple projects at…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $ nx semantic-release app-c --repositoryUrl "https://github.com/TheUnderScorer/n
 | repositoryUrl  | string             | repositoryUrl                                                                  | no       | The URL of the repository to release from.                                                                                                                                                                                                                                                                                      |
 | tagFormat      | string             | ${PROJECT_NAME}-v${version}                                                    | no       | Tag format to use. You can refer to [semantic-release configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#tagformat)                                                                                                                                                    |
 | npm            | boolean            | true                                                                           | no       | Whether to bump package.json version and publish to registry (if package is public).                                                                                                                                                                                                                                            |
-| git            | boolean            | true                                                                           | no       | Whether to create git commit and tag. See more in [@semantic-release/git](https://github.com/semantic-release/git).                                                                                                                                                                                                                                                                                               |
+| git            | boolean            | true                                                                           | no       | Whether to create git commit and tag. See more in [@semantic-release/git](https://github.com/semantic-release/git).                                                                                                                                                                                                             |
 | github         | boolean            | true                                                                           | no       | Whether to create github release.                                                                                                                                                                                                                                                                                               |
 | buildTarget    | string             |                                                                                | no       | The target of the build command. If your package is public and you want to release it to npm as part of release, you have to provide it. Plugin will use it to build your package and set version in package.json before releasing it to npm registry.                                                                          |
 | outputPath     | string             |                                                                                | no       | The path to the output directory. Provide that if your package is public and you want to publish it into npm.                                                                                                                                                                                                                   |
@@ -151,16 +151,17 @@ want to publish released package to npm registry.
 
 ## Skipping commits
 
-You can skip commits for given project using `[skip $PROJECT_NAME]` in its body. Ex:
+You can skip commits for given projects using `[skip $PROJECT_NAME]` in its body. Ex:
 
 ```
   feat: update something
 
-  [skip my-app]
+  [skip my-app1]
+  [skip my-app2]
 ```
 
-During analysis this commit will be skipped for release pipeline for my-app.
-You can also use `[skip all]` to skip commit for all projects.
+During analysis this commit will be skipped for release pipeline for `my-app1`, `my-app2`.
+You can also use `[skip all]` to skip commit for all projects or **one single** `[skip my-app1, my-app2]` to skip commits related to `my-app1`, `my-app2` at once.
 
 ---
 
@@ -169,9 +170,12 @@ Alternatively you can include only particular projects in given commit by using 
 ```
   feat: update something
 
-  [only my-app]
+  [only my-app1]
+  [only my-app2]
 ```
-During analysis this commit will be included only for release pipeline for my-app.
+During analysis this commit will be included only for release pipeline for `my-app`, `my-app2`.
+You can also use **one single** `[skip my-app1, my-app2]` to skip commits related to `my-app1`, `my-app2` at once.
+
 
 ## CI/CD
 

--- a/packages/nx-semantic-release/src/common/git.spec.ts
+++ b/packages/nx-semantic-release/src/common/git.spec.ts
@@ -13,6 +13,26 @@ describe('git', () => {
       expect(result).toEqual(true);
     });
 
+    it('should skip commit if [skip project, project2] flag is set', () => {
+      const result1 = shouldSkipCommit(
+        {
+          body: '[skip project, project2]',
+        },
+        'project'
+      );
+
+      expect(result1).toEqual(true);
+
+      const result2 = shouldSkipCommit(
+        {
+          body: '[skip project, project2]',
+        },
+        'project2'
+      );
+
+      expect(result2).toEqual(true);
+    });
+
     it('should skip commit if [skip all] flag is set', () => {
       const result = shouldSkipCommit(
         {
@@ -35,10 +55,42 @@ describe('git', () => {
       expect(result).toEqual(false);
     });
 
+    it('should not skip commit if [skip project, project2] flag is not set in the body', () => {
+      const result1 = shouldSkipCommit(
+        {
+          body: '',
+        },
+        'project'
+      );
+
+      expect(result1).toEqual(false);
+
+      const result2 = shouldSkipCommit(
+        {
+          body: '',
+        },
+        'project2'
+      );
+
+      expect(result2).toEqual(false);
+    });
+
     it('should skip commit if it has [only other-project] flag', () => {
       const result = shouldSkipCommit(
         {
           body: '[only other-project]',
+        },
+        'project'
+      );
+
+      expect(result).toEqual(true);
+    });
+
+
+    it('should skip commit if it has [only other-project, other-project2,] flag', () => {
+      const result = shouldSkipCommit(
+        {
+          body: '[only other-project, other-project2]',
         },
         'project'
       );
@@ -55,6 +107,26 @@ describe('git', () => {
       );
 
       expect(result).toEqual(false);
+    });
+
+    it('should not skip commit if it includes [only project, project2] flag', () => {
+      const result1 = shouldSkipCommit(
+        {
+          body: '[only project, project2]',
+        },
+        'project'
+      );
+
+      expect(result1).toEqual(false);
+
+      const result2 = shouldSkipCommit(
+        {
+          body: '[only project, project2]',
+        },
+        'project2'
+      );
+
+      expect(result2).toEqual(false);
     });
   });
 });

--- a/packages/nx-semantic-release/src/common/git.ts
+++ b/packages/nx-semantic-release/src/common/git.ts
@@ -65,17 +65,20 @@ export function shouldSkipCommit(
   projectName: string
 ): boolean {
   const onlyMatchRegex = /\[only (.*?)]/g;
+  const skipMatchRegex = /\[skip (.*?)]/g;
 
-  const skipMatches = [`[skip ${projectName}]`, '[skip all]'];
+  const skipAll = '[skip all]';
+  const skipMatches = Array.from(commit.body.matchAll(skipMatchRegex));
   const onlyMatches = Array.from(commit.body.matchAll(onlyMatchRegex));
 
   const hasOnlyMatch =
     onlyMatches.length &&
-    !onlyMatches.some((match) => match[1] === projectName);
+    !onlyMatches.some((match) =>  match[1].split(',').map(project => project.trim()).some((project) => project === projectName));
 
-  const hasSkipMatch = skipMatches.some((skipMatch) =>
-    commit.body.includes(skipMatch)
-  );
+  const hasSkipMatch = 
+    commit.body.includes(skipAll) ||
+    skipMatches.length &&
+    skipMatches.some((match) =>  match[1].split(',').map(project => project.trim()).some((project) => project === projectName));
 
   return Boolean(hasSkipMatch || hasOnlyMatch);
 }


### PR DESCRIPTION
… once

Using `[skip project1, project2, ...projectN]`  (resp. `[only project1, project2, ...projectN]`) syntax, you can now skip (resp. include) commits affecting `project1`, `project2`, ...`projectN` **at once**